### PR TITLE
Feat:마이페이지 수정 기능 API 구현

### DIFF
--- a/src/main/java/org/baljaguk/domain/category/repository/UserCategoryRepository.java
+++ b/src/main/java/org/baljaguk/domain/category/repository/UserCategoryRepository.java
@@ -2,6 +2,10 @@ package org.baljaguk.domain.category.repository;
 
 import org.baljaguk.domain.category.entity.UserCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.baljaguk.domain.user.entity.User;
 
 public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
+
+    void deleteAllByUser(User user);
+
 }

--- a/src/main/java/org/baljaguk/domain/user/controller/UserController.java
+++ b/src/main/java/org/baljaguk/domain/user/controller/UserController.java
@@ -75,7 +75,6 @@ public class UserController {
 
         return ResponseEntity.ok(ApiResponse.ok("관심 분야가 수정되었습니다."));
     }
-}
 
     @GetMapping("/my-profile")
     @Operation(summary = "유저 마이프로필 조회",

--- a/src/main/java/org/baljaguk/domain/user/controller/UserController.java
+++ b/src/main/java/org/baljaguk/domain/user/controller/UserController.java
@@ -60,7 +60,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.ok("학력 정보가 수정되었습니다."));
     }
 
-    @PatchMapping("/interests")
+    @PatchMapping("/categories")
     @Operation(summary = "관심 분야(Category) 수정 API",
             description = "로그인한 사용자의 관심 분야를 수정합니다.\n" +
                     "카테고리 ID 리스트(예: `[1, 3, 5]`)를 보내면 기존 관심사는 삭제되고 새로 저장됩니다.\n" +

--- a/src/main/java/org/baljaguk/domain/user/controller/UserController.java
+++ b/src/main/java/org/baljaguk/domain/user/controller/UserController.java
@@ -5,15 +5,15 @@ import jakarta.validation.Valid;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.baljaguk.domain.user.dto.CustomUserDetails;
+import org.baljaguk.domain.user.dto.request.CategoryUpdateRequest;
+import org.baljaguk.domain.user.dto.request.EducationUpdateRequest;
+import org.baljaguk.domain.user.dto.request.SkillUpdateRequest;
 import org.baljaguk.domain.user.dto.request.UserUpdateRequest;
 import org.baljaguk.domain.user.service.UserService;
 import org.baljaguk.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/users")
@@ -31,5 +31,47 @@ public class UserController {
     ) {
         userService.updateUserProfile(userDetails.getUser().getId(), request);
         return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @PatchMapping("/skills")
+    @Operation(summary = "스킬셋 수정 API",
+            description = "로그인한 사용자의 스킬셋 정보를 수정합니다.\n" +
+                    "스킬들을 리스트 형태(['Java', 'Spring'])로 요청하면, DB에는 콤마로 구분된 문자열로 저장됩니다.\n" +
+                    "빈 리스트([])를 보내면 스킬셋이 초기화됩니다.")
+    public ResponseEntity<ApiResponse<Void>> updateMySkills(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody SkillUpdateRequest request
+    ) {
+        userService.updateMySkills(userDetails.getUser().getId(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @PatchMapping("/education")
+    @Operation(summary = "학력 정보 수정 API",
+            description = "로그인한 사용자의 **대학교명, 전공, 학력 상태(Enum), 학위(Enum)** 네 가지 정보를 모두 수정합니다."
+    )
+    public ResponseEntity<ApiResponse<String>> updateEducation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody EducationUpdateRequest request
+    ) {
+        userService.updateEducation(userDetails.getUser().getId(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok("학력 정보가 수정되었습니다."));
+    }
+
+    @PatchMapping("/interests")
+    @Operation(summary = "관심 분야(Category) 수정 API",
+            description = "로그인한 사용자의 관심 분야를 수정합니다.\n" +
+                    "카테고리 ID 리스트(예: `[1, 3, 5]`)를 보내면 기존 관심사는 삭제되고 새로 저장됩니다.\n" +
+                    "빈 리스트 `[]`를 보내면 관심사가 모두 삭제(초기화)됩니다."
+    )
+    public ResponseEntity<ApiResponse<String>> updateInterests(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CategoryUpdateRequest request
+    ) {
+        userService.updateInterests(userDetails.getUser().getId(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok("관심 분야가 수정되었습니다."));
     }
 }

--- a/src/main/java/org/baljaguk/domain/user/dto/request/CategoryUpdateRequest.java
+++ b/src/main/java/org/baljaguk/domain/user/dto/request/CategoryUpdateRequest.java
@@ -1,7 +1,7 @@
 package org.baljaguk.domain.user.dto.request;
 
-import java.util.List;
+import java.util.Set;
 
 public record CategoryUpdateRequest(
-        List<Long> categoryIds
+        Set<Long> categoryIds
 ) {}

--- a/src/main/java/org/baljaguk/domain/user/dto/request/CategoryUpdateRequest.java
+++ b/src/main/java/org/baljaguk/domain/user/dto/request/CategoryUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.baljaguk.domain.user.dto.request;
+
+import java.util.List;
+
+public record CategoryUpdateRequest(
+        List<Long> categoryIds
+) {}

--- a/src/main/java/org/baljaguk/domain/user/dto/request/EducationUpdateRequest.java
+++ b/src/main/java/org/baljaguk/domain/user/dto/request/EducationUpdateRequest.java
@@ -1,0 +1,11 @@
+package org.baljaguk.domain.user.dto.request;
+
+import org.baljaguk.domain.user.entity.enums.Education;
+import org.baljaguk.domain.user.entity.enums.RecognizedDegree;
+
+public record EducationUpdateRequest(
+        String universityName,
+        String major,
+        Education education,              // 학력 상태 (Enum)
+        RecognizedDegree recognizedDegree // 학위 (Enum)
+) {}

--- a/src/main/java/org/baljaguk/domain/user/dto/request/SkillUpdateRequest.java
+++ b/src/main/java/org/baljaguk/domain/user/dto/request/SkillUpdateRequest.java
@@ -1,0 +1,8 @@
+package org.baljaguk.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record SkillUpdateRequest(
+        List<String> skills
+) {}

--- a/src/main/java/org/baljaguk/domain/user/entity/User.java
+++ b/src/main/java/org/baljaguk/domain/user/entity/User.java
@@ -2,10 +2,12 @@ package org.baljaguk.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.baljaguk.domain.category.entity.UserCategory;
 import org.baljaguk.domain.user.dto.request.UserUpdateRequest;
 import org.baljaguk.domain.user.entity.enums.Education;
 import org.baljaguk.domain.user.entity.enums.RecognizedDegree;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity

--- a/src/main/java/org/baljaguk/domain/user/entity/User.java
+++ b/src/main/java/org/baljaguk/domain/user/entity/User.java
@@ -2,12 +2,10 @@ package org.baljaguk.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.baljaguk.domain.category.entity.UserCategory;
 import org.baljaguk.domain.user.dto.request.UserUpdateRequest;
 import org.baljaguk.domain.user.entity.enums.Education;
 import org.baljaguk.domain.user.entity.enums.RecognizedDegree;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -84,5 +82,23 @@ public class User {
 
         this.education = request.education();
         this.recognizedDegree = request.recognizedDegree();
+    }
+
+
+    // 스킬셋 수정 메서드
+    public void updateSkills(java.util.List<String> newSkills) {
+        if (newSkills == null || newSkills.isEmpty()) {
+            this.skills = null;
+        } else {
+            this.skills = newSkills.stream()
+                    .collect(java.util.stream.Collectors.joining(","));
+        }
+    }
+
+    public void updateEducation(String universityName, String major, Education education, RecognizedDegree recognizedDegree) {
+        this.universityName = universityName;
+        this.major = major;
+        this.education = education;
+        this.recognizedDegree = recognizedDegree;
     }
 }

--- a/src/main/java/org/baljaguk/domain/user/service/UserService.java
+++ b/src/main/java/org/baljaguk/domain/user/service/UserService.java
@@ -1,7 +1,18 @@
 package org.baljaguk.domain.user.service;
 
+import org.baljaguk.domain.user.dto.request.CategoryUpdateRequest;
+import org.baljaguk.domain.user.dto.request.EducationUpdateRequest;
+import org.baljaguk.domain.user.dto.request.SkillUpdateRequest;
 import org.baljaguk.domain.user.dto.request.UserUpdateRequest;
 
 public interface UserService {
     void updateUserProfile(Long id, UserUpdateRequest request);
+
+    void updateMySkills(Long userId, SkillUpdateRequest request);
+
+    void updateEducation(Long userId, EducationUpdateRequest request);
+
+    void updateInterests(Long userId, CategoryUpdateRequest request);
 }
+
+

--- a/src/main/java/org/baljaguk/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/user/service/UserServiceImpl.java
@@ -93,7 +93,7 @@ public class UserServiceImpl implements UserService {
             userCategoryRepository.saveAll(newUserCategories);
         }
     }
-}
+
     public ProfileResponse getMyProfile(Long userId) {
 
         User user = userRepository.findUserWithCategories(userId)

--- a/src/main/java/org/baljaguk/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/user/service/UserServiceImpl.java
@@ -5,7 +5,10 @@ import org.baljaguk.domain.category.entity.Category;
 import org.baljaguk.domain.category.entity.UserCategory;
 import org.baljaguk.domain.category.repository.CategoryRepository;
 import org.baljaguk.domain.category.repository.UserCategoryRepository;
+import org.baljaguk.domain.user.dto.request.EducationUpdateRequest;
 import org.baljaguk.domain.user.dto.request.UserUpdateRequest;
+import org.baljaguk.domain.user.dto.request.SkillUpdateRequest; //추가됨
+import org.baljaguk.domain.user.dto.request.CategoryUpdateRequest; // 추가됨
 import org.baljaguk.domain.user.entity.User;
 import org.baljaguk.domain.user.repository.UserRepository;
 import org.baljaguk.global.api.ErrorCode;
@@ -45,6 +48,48 @@ public class UserServiceImpl implements UserService {
                     .toList();
 
             userCategoryRepository.saveAll(userCategories);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateMySkills(Long userId, SkillUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+
+        user.updateSkills(request.skills());
+    }
+
+    @Override
+    @Transactional
+    public void updateEducation(Long userId, EducationUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+
+        user.updateEducation(
+                request.universityName(),
+                request.major(),
+                request.education(),
+                request.recognizedDegree()
+        );
+    }
+
+    @Override
+    @Transactional
+    public void updateInterests(Long userId, CategoryUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+
+        userCategoryRepository.deleteAllByUser(user);
+
+        if (request.categoryIds() != null && !request.categoryIds().isEmpty()) {
+            List<Category> categories = categoryRepository.findAllById(request.categoryIds());
+
+            List<UserCategory> newUserCategories = categories.stream()
+                    .map(category -> UserCategory.of(user, category))
+                    .toList();
+
+            userCategoryRepository.saveAll(newUserCategories);
         }
     }
 }

--- a/src/main/java/org/baljaguk/global/config/SecurityConfig.java
+++ b/src/main/java/org/baljaguk/global/config/SecurityConfig.java
@@ -90,7 +90,13 @@ public class SecurityConfig {
 
         // 인가 경로 설정
         http.authorizeHttpRequests((auth)->auth
-                .requestMatchers("/api/v1/auth/google/**").permitAll()
+                .requestMatchers("/oauth/google/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/swagger-resources/**",
+                        "/webjars/**",
+                        "/access").permitAll()
                 .anyRequest().authenticated());
 
         http


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. --> 

- close #7

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
1. 학력 정보 수정 API
- `PATCH /api/v1/users/me/education`
- 대학교명, 전공, 학력 상태(`Education` Enum), 학위(`RecognizedDegree` Enum) 4가지 정보를 수정합니다.
- Enum 값은 대문자(예: `ATTENDING`, `BACHELOR`)로 처리되도록 구현했습니다.

2. 스킬셋 수정 API
- `PATCH /api/v1/users/me/skills`
- 사용자의 스킬 리스트를 받아 DB에 업데이트합니다.

3. 관심 분야 수정 API
`PATCH /api/v1/users/me/interests`

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 --> 

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
Swagger를 통한 API 호출 테스트 완료 (200 OK) + DB에 값 수정되는 것도 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 업데이트 강화: 기술(스킬), 교육 정보(대학교명·전공·학위 상태), 관심사(카테고리)를 각각 별도 엔드포인트로 수정 가능해졌습니다.
  * 관심사 업데이트 시 기존 선택 항목이 초기화되고 새 선택 항목으로 갱신됩니다.

<sub>✏️ Tip: 리뷰 설정에서 이 요약을 커스터마이즈할 수 있습니다.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->