### PR TITLE
Feature/채팅 목록 전체 조회

### DIFF
--- a/src/main/java/org/baljaguk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/baljaguk/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,32 @@
+package org.baljaguk.domain.chat.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.chat.entity.dto.ChatRoomListResponse;
+import org.baljaguk.domain.chat.service.ChatRoomService;
+import org.baljaguk.domain.user.dto.CustomUserDetails;
+import org.baljaguk.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/chat")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/rooms")
+    @Operation(summary = "채팅방 목록 조회",
+            description = "사용자가 속한 모든 채팅방 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<ChatRoomListResponse>> getAllChatRooms(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        ChatRoomListResponse response = chatRoomService.getChatRooms(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomListResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomListResponse.java
@@ -1,0 +1,12 @@
+package org.baljaguk.domain.chat.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomListResponse {
+    private List<ChatRoomResponse> chatRooms;
+}

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomResponse.java
@@ -1,0 +1,20 @@
+package org.baljaguk.domain.chat.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.team.dto.ContestInfoDto;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
+public class ChatRoomResponse {
+
+    private Long chatroomId;
+
+    private ContestInfoDto contestInfo;
+
+    private LastChatInfoDto lastChatInfo;
+}

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/LastChatInfoDto.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/LastChatInfoDto.java
@@ -1,18 +1,14 @@
 package org.baljaguk.domain.chat.entity.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class LastChatInfoDto {
     private String lastMessage;
     private LocalDateTime lastMessageAt;
-    private Integer unReadCount;
+    private Long unReadMessageCount;
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/LastChatInfoDto.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/LastChatInfoDto.java
@@ -1,0 +1,18 @@
+package org.baljaguk.domain.chat.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LastChatInfoDto {
+    private String lastMessage;
+    private LocalDateTime lastMessageAt;
+    private Integer unReadCount;
+}

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepository.java
@@ -3,5 +3,5 @@ package org.baljaguk.domain.chat.repository;
 import org.baljaguk.domain.chat.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
 }

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryCustom.java
@@ -1,0 +1,12 @@
+package org.baljaguk.domain.chat.repository;
+
+import org.baljaguk.domain.chat.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public interface ChatMessageRepositoryCustom {
+    Map<Long, Long> getUnreadCounts(Map<Long, LocalDateTime> lastReadTimes);
+    List<ChatMessage> findLatestMessagesByRoomIds(List<Long> roomIds);
+}

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,77 @@
+package org.baljaguk.domain.chat.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.chat.entity.ChatMessage;
+import org.baljaguk.domain.chat.entity.QChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, Long> getUnreadCounts(Map<Long, LocalDateTime> lastReadTimes) {
+        if (lastReadTimes == null || lastReadTimes.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        QChatMessage chatMessage = QChatMessage.chatMessage;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 각 채팅방마다 마지막으로 읽은 시간 이후의 메시지를 조회하는 조건을 동적으로 생성
+        for (Map.Entry<Long, LocalDateTime> entry : lastReadTimes.entrySet()) {
+            Long roomId = entry.getKey();
+            LocalDateTime lastReadAt = entry.getValue();
+            if (lastReadAt != null) {
+                builder.or(chatMessage.chatRoom.id.eq(roomId).and(chatMessage.createdAt.gt(lastReadAt)));
+            }
+        }
+
+        if (!builder.hasValue()) {
+            return Collections.emptyMap();
+        }
+
+        // 조건에 맞는 메시지들을 채팅방 ID로 그룹화하여 개수를 계산
+        return queryFactory
+                .select(chatMessage.chatRoom.id, chatMessage.count())
+                .from(chatMessage)
+                .where(builder)
+                .groupBy(chatMessage.chatRoom.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(chatMessage.chatRoom.id),
+                        tuple -> tuple.get(chatMessage.count())
+                ));
+    }
+
+    @Override
+    public List<ChatMessage> findLatestMessagesByRoomIds(List<Long> roomIds) {
+        if (roomIds == null || roomIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        QChatMessage chatMessage = QChatMessage.chatMessage;
+        QChatMessage subChatMessage = new QChatMessage("subChatMessage");
+
+        // 각 채팅방 ID별로 가장 최근 메시지 ID(max(id))를 찾는 서브쿼리 사용
+        return queryFactory
+                .selectFrom(chatMessage)
+                .where(chatMessage.id.in(
+                        JPAExpressions.select(subChatMessage.id.max())
+                                .from(subChatMessage)
+                                .where(subChatMessage.chatRoom.id.in(roomIds))
+                                .groupBy(subChatMessage.chatRoom.id)
+                ))
+                .fetch();
+    }
+}

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,13 @@ package org.baljaguk.domain.chat.repository;
 
 import org.baljaguk.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    @Query("SELECT cr FROM ChatRoom cr JOIN FETCH cr.team WHERE cr.team.id IN :teamIds")
+    List<ChatRoom> findByTeamIdIn(@Param("teamIds") List<Long> teamIds);
 }

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.baljaguk.domain.chat.repository;
+
+
+import java.util.List;
+
+public interface ChatRoomRepositoryCustom {
+    List<Long> findChatRoomIdsByTeamIds (List<Long> teamId);
+}

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package org.baljaguk.domain.chat.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.chat.entity.QChatRoom;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<Long> findChatRoomIdsByTeamIds(List<Long> teamIds) {
+
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+
+        //null 확인
+        if (teamIds == null || teamIds.isEmpty()) return List.of();
+
+        return queryFactory.select(chatRoom.id)
+                .from(chatRoom)
+                .where(chatRoom.team.id.in(teamIds))
+                .fetch();
+    }
+}

--- a/src/main/java/org/baljaguk/domain/chat/repository/LastReadTimeRepository.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/LastReadTimeRepository.java
@@ -3,9 +3,12 @@ package org.baljaguk.domain.chat.repository;
 import org.baljaguk.domain.chat.entity.LastReadTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LastReadTimeRepository extends JpaRepository<LastReadTime, Long> {
 
     Optional<LastReadTime> findByUserIdAndRoomId(long userId, long roomId);
+
+    List<LastReadTime> findByUserId(Long userId);
 }

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,89 @@
+package org.baljaguk.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.chat.entity.ChatMessage;
+import org.baljaguk.domain.chat.entity.ChatRoom;
+import org.baljaguk.domain.chat.entity.LastReadTime;
+import org.baljaguk.domain.chat.entity.dto.ChatRoomListResponse;
+import org.baljaguk.domain.chat.entity.dto.ChatRoomResponse;
+import org.baljaguk.domain.chat.entity.dto.LastChatInfoDto;
+import org.baljaguk.domain.chat.repository.ChatMessageRepository;
+import org.baljaguk.domain.chat.repository.ChatRoomRepository;
+import org.baljaguk.domain.chat.repository.LastReadTimeRepository;
+import org.baljaguk.domain.team.dto.ContestInfoDto;
+import org.baljaguk.domain.team.repository.TeamMemberRepository;
+import org.baljaguk.domain.team.repository.TeamRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamRepository teamRepository;
+    private final LastReadTimeRepository lastReadTimeRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+
+    public ChatRoomListResponse getChatRooms(Long userId) {
+
+        // 1. 사용자가 속한 모든 teamId 조회
+        List<Long> teamIds = teamMemberRepository.findTeamIdsByMemberId(userId);
+        if (teamIds.isEmpty()) {
+            return new ChatRoomListResponse(Collections.emptyList());
+        }
+
+        // 2. teamId 목록으로 모든 ChatRoom 엔티티 조회 ->roomIds로 변환
+        List<ChatRoom> chatRooms = chatRoomRepository.findByTeamIdIn(teamIds);
+        List<Long> roomIds = chatRooms.stream().map(ChatRoom::getId).collect(Collectors.toList());
+        if (roomIds.isEmpty()) {
+            return new ChatRoomListResponse(Collections.emptyList());
+        }
+
+        // 3. teamId 목록으로 ContestInfoDto 조회 -> Map<teamId, ContestInfoDto>
+        Map<Long, ContestInfoDto> contestInfoMap = teamRepository.findContestInfoByTeamIds(teamIds)
+                .stream()
+                .collect(Collectors.toMap(ContestInfoDto::getTeamId, Function.identity()));
+
+        // 4. 사용자의 마지막 읽은 시간 정보 조회 -> Map<roomId, LocalDateTime>
+        Map<Long, LocalDateTime> lastReadTimeMap = lastReadTimeRepository.findByUserId(userId)
+                .stream()
+                .collect(Collectors.toMap(LastReadTime::getRoomId, LastReadTime::getLastReadAt));
+
+        // 5. 안 읽은 메시지 수 조회 -> Map<roomId, unreadCount>
+        Map<Long, Long> unreadCountMap = chatMessageRepository.getUnreadCounts(lastReadTimeMap);
+
+        // 6. 최신 메시지 정보 조회 -> Map<roomId, ChatMessage>
+        Map<Long, ChatMessage> latestMessageMap = chatMessageRepository.findLatestMessagesByRoomIds(roomIds)
+                .stream()
+                .collect(Collectors.toMap(msg -> msg.getChatRoom().getId(), Function.identity()));
+
+        // 7. 데이터 조립
+        List<ChatRoomResponse> chatRoomResponses = chatRooms.stream().map(room -> {
+
+            ContestInfoDto contestInfo = contestInfoMap.get(room.getTeam().getId());
+            long unreadCount = unreadCountMap.getOrDefault(room.getId(), 0L);
+            ChatMessage latestMessage = latestMessageMap.get(room.getId());
+
+            LastChatInfoDto lastChatInfo = LastChatInfoDto.builder()
+                    .lastMessage(latestMessage != null ? latestMessage.getMessage() : "아직 메시지가 없습니다.")
+                    .lastMessageAt(latestMessage != null ? latestMessage.getCreatedAt() : null)
+                    .unReadMessageCount(unreadCount)
+                    .build();
+
+            return new ChatRoomResponse(room.getId(), contestInfo, lastChatInfo);
+        }).collect(Collectors.toList());
+
+        return new ChatRoomListResponse(chatRoomResponses);
+    }
+}

--- a/src/main/java/org/baljaguk/domain/chat/service/StompHandler.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/StompHandler.java
@@ -3,7 +3,6 @@ package org.baljaguk.domain.chat.service;
 import org.baljaguk.domain.user.dto.CustomUserDetails;
 import org.baljaguk.domain.user.entity.User;
 import org.baljaguk.domain.user.repository.UserRepository;
-import org.baljaguk.domain.user.service.UserServiceImpl;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import lombok.NonNull;
@@ -39,7 +38,7 @@ public class StompHandler implements ChannelInterceptor {
     private static final String USER_ID_KEY = "userId";
     private static final String ROOM_ID_KEY = "roomId";
 
-    // 채팅방 구독 경로 패턴: /topic/chat.room.{roomId}
+    // SUBSCRIBE 프레임의 destination 헤더에서 roomId를 추출
     private static final Pattern ROOM_ID_PATTERN = Pattern.compile("/topic/chat\\.room\\.(\\d+)");
     private final JWTUtil jwtUtil;
     @Lazy
@@ -67,6 +66,7 @@ public class StompHandler implements ChannelInterceptor {
         }
         // 2. SUBSCRIBE 명령어 처리 (roomId 저장)
         else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            log.info("subscribe: {}", sessionAttributes);
             handleSubscribe(accessor, sessionAttributes);
         }
         // 3. DISCONNECT 명령어 처리 (단순 로깅)

--- a/src/main/java/org/baljaguk/domain/team/dto/ContestInfoDto.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/ContestInfoDto.java
@@ -1,0 +1,22 @@
+package org.baljaguk.domain.team.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ContestInfoDto {
+    private Long contestId;
+    private Long teamId;
+    private String contestName;
+    private String imageUrl;
+
+    @QueryProjection
+    public ContestInfoDto(Long contestId, Long teamId, String contestName, String imageUrl) {
+        this.contestId = contestId;
+        this.teamId = teamId;
+        this.contestName = contestName;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamMemberRepositoryCustom.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamMemberRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface TeamMemberRepositoryCustom {
     List<TeamMember> findAllWithUserByTeamId(Long teamId);
+    List<Long> findTeamIdsByMemberId(Long teamId);
 }

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamMemberRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamMemberRepositoryImpl.java
@@ -25,4 +25,19 @@ public class TeamMemberRepositoryImpl implements TeamMemberRepositoryCustom {
                 .where(tm.team.id.eq(teamId))
                 .fetch();
     }
+
+    @Override
+    public List<Long> findTeamIdsByMemberId(Long memberId) {
+
+        QTeamMember teamMember = QTeamMember.teamMember;
+
+
+        return queryFactory
+                .select(teamMember.team.id)
+                .from(teamMember)
+                .where(teamMember.member.id.eq(memberId))
+                .fetch(); //List 형태 반환
+    }
+
 }
+

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamRepositoryCustom.java
@@ -1,6 +1,6 @@
 package org.baljaguk.domain.team.repository;
 
-import org.baljaguk.domain.team.dto.response.MyRecruitListResponse;
+import org.baljaguk.domain.team.dto.ContestInfoDto;
 import org.baljaguk.domain.team.entity.Team;
 import org.baljaguk.domain.team.entity.TeamStatus;
 
@@ -15,5 +15,7 @@ public interface TeamRepositoryCustom {
     List<Team> findClosedTeamsByUserId(Long userId);
 
     Optional<Team> findTeamWithContestByTeamId(Long teamId);
+
+    List<ContestInfoDto> findContestInfoByTeamIds(List<Long> teamIds);
 
 }

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamRepositoryImpl.java
@@ -3,17 +3,18 @@ package org.baljaguk.domain.team.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.team.dto.ContestInfoDto;
 import org.baljaguk.domain.contest.entity.QContest;
-import org.baljaguk.domain.team.dto.response.MyRecruitListResponse;
+import org.baljaguk.domain.team.dto.QContestInfoDto;
 import org.baljaguk.domain.team.entity.*;
 import org.springframework.stereotype.Repository;
-import org.baljaguk.domain.team.entity.RegisterStatus;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+// Q-클래스 임포트
 import static org.baljaguk.domain.team.entity.QTeam.team;
 
 @Repository
@@ -26,7 +27,7 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom{
     public Map<Long, Long> countByContestIdsGrouped(List<Long> contestIds, TeamStatus status) {
 
         if (contestIds == null || contestIds.isEmpty()) {
-                return Map.of();
+            return Map.of();
         }
 
         List<Tuple> results = queryFactory
@@ -80,5 +81,27 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom{
                 .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+
+    @Override
+    public List<ContestInfoDto>findContestInfoByTeamIds(List<Long> teamIds){
+
+        QTeam qTeam = QTeam.team;
+        QContest qContest = QContest.contest;
+
+        if (teamIds == null || teamIds.isEmpty()) return List.of();
+
+        return queryFactory
+                .from(qTeam)
+                .join(qTeam.contest, qContest)
+                .where(qTeam.id.in(teamIds))
+                .select(new QContestInfoDto(
+                        qContest.id,        // contestId
+                        qContest.name,      // contestName
+                        qContest.imageUrl,       // contestUrl
+                        qTeam.id            // teamId
+                ))
+                .fetch();
     }
 }

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamRepositoryImpl.java
@@ -98,9 +98,9 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom{
                 .where(qTeam.id.in(teamIds))
                 .select(new QContestInfoDto(
                         qContest.id,        // contestId
-                        qContest.name,      // contestName
-                        qContest.imageUrl,       // contestUrl
-                        qTeam.id            // teamId
+                        qTeam.id,      // TeamId
+                        qContest.name,       // contestName
+                        qContest.imageUrl            // contestUrl
                 ))
                 .fetch();
     }

--- a/src/main/java/org/baljaguk/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/user/service/UserServiceImpl.java
@@ -11,7 +11,6 @@ import org.baljaguk.domain.user.dto.response.UserSkillsResponse;
 import org.baljaguk.domain.user.entity.User;
 import org.baljaguk.domain.user.repository.UserRepository;
 import org.baljaguk.global.api.ErrorCode;
-import org.baljaguk.global.api.GeneralException;
 import org.baljaguk.global.api.handler.CategoryException;
 import org.baljaguk.global.api.handler.UserException;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #32 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 채팅방 목록 전체 조회
- access token -> userId로 user가 속해있는 모든 채팅 관련 정보 GET
-  응답 : 채팅방 id , 공모전 정보(공모전 id, 공모전 이름, 공모전 이미지url), 마지막 메시지 정보(마지막 메시지, 마지막 메시지 시간, 안 읽은 메시지 수)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

없음 띠

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
<img width="899" height="392" alt="image" src="https://github.com/user-attachments/assets/4c2a8087-045f-4b31-9338-32f9e65a25a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증된 사용자의 채팅방 목록 조회 기능 추가
  * 각 채팅방별 최근 메시지, 타임스탬프, 미읽음 메시지 수 표시
  * 채팅방과 연관된 대회 정보 표시

* **버그 수정**
  * 채팅 세션 속성 초기화 시 방어적 null 체크 추가

* **Chores**
  * 미사용 임포트 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->