### PR TITLE
chore(채팅방 목록): response에 팀원 수 추가

### DIFF
--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomResponse.java
@@ -18,5 +18,5 @@ public class ChatRoomResponse {
 
     private LastChatInfoDto lastChatInfo;
 
-    private Long teamMemeberCount;
+    private Long teamMemberCount;
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatRoomResponse.java
@@ -17,4 +17,6 @@ public class ChatRoomResponse {
     private ContestInfoDto contestInfo;
 
     private LastChatInfoDto lastChatInfo;
+
+    private Long teamMemeberCount;
 }

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
@@ -68,7 +68,14 @@ public class ChatRoomService {
                 .stream()
                 .collect(Collectors.toMap(msg -> msg.getChatRoom().getId(), Function.identity()));
 
-        // 7. 데이터 조립
+        // 7. 팀 맴버 수 조회 -> Map<roomId, teamMemberCount>
+        Map<Long, Long> teamMemberCounts = teamIds.stream()
+                .collect(Collectors.toMap(
+                        teamId -> teamId,
+                        teamMemberRepository::countByTeamId
+                ));
+
+        // 8. 데이터 조립
         List<ChatRoomResponse> chatRoomResponses = chatRooms.stream().map(room -> {
 
             ContestInfoDto contestInfo = contestInfoMap.get(room.getTeam().getId());
@@ -77,13 +84,13 @@ public class ChatRoomService {
 
             ChatMessage latestMessage = latestMessageMap.get(room.getId());
 
-            Long teamMemberCount=teamMemberRepository.countByTeam(room.getTeam());
-
             LastChatInfoDto lastChatInfo = LastChatInfoDto.builder()
                     .lastMessage(latestMessage != null ? latestMessage.getMessage() : "아직 메시지가 없습니다.")
                     .lastMessageAt(latestMessage != null ? latestMessage.getCreatedAt() : null)
                     .unReadMessageCount(unreadCount)
                     .build();
+
+            Long teamMemberCount = teamMemberCounts.get(room.getTeam().getId());
 
             return new ChatRoomResponse(room.getId(), contestInfo, lastChatInfo,teamMemberCount);
         }).collect(Collectors.toList());

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
@@ -72,8 +72,12 @@ public class ChatRoomService {
         List<ChatRoomResponse> chatRoomResponses = chatRooms.stream().map(room -> {
 
             ContestInfoDto contestInfo = contestInfoMap.get(room.getTeam().getId());
+
             long unreadCount = unreadCountMap.getOrDefault(room.getId(), 0L);
+
             ChatMessage latestMessage = latestMessageMap.get(room.getId());
+
+            Long teamMemberCount=teamMemberRepository.countByTeam(room.getTeam());
 
             LastChatInfoDto lastChatInfo = LastChatInfoDto.builder()
                     .lastMessage(latestMessage != null ? latestMessage.getMessage() : "아직 메시지가 없습니다.")
@@ -81,7 +85,7 @@ public class ChatRoomService {
                     .unReadMessageCount(unreadCount)
                     .build();
 
-            return new ChatRoomResponse(room.getId(), contestInfo, lastChatInfo);
+            return new ChatRoomResponse(room.getId(), contestInfo, lastChatInfo,teamMemberCount);
         }).collect(Collectors.toList());
 
         return new ChatRoomListResponse(chatRoomResponses);

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamMemberRepository.java
@@ -17,4 +17,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long>, T
     Optional<TeamMember> findByTeamAndMember(Team team, User member);
 
     Optional<TeamMember> findByTeamIdAndMemberId(Long teamId, Long memberId);
+
+    Long countByTeamId(Long teamId);
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #59 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

chatroom response에 팀원 수 필드를 추가했고 기존 teamMemberRepository에 있던 coutByTeam을 사용해 서비스 코드에서 build 과정에 이를 추가했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
<img width="767" height="283" alt="image" src="https://github.com/user-attachments/assets/fa84438c-6492-44b9-865c-d86e194694f6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방 조회 응답에 팀 멤버 수(team member count)가 추가되어 각 채팅방에 소속 인원 수를 확인할 수 있습니다.
  * 기존의 읽지 않은 메시지 수와 마지막 메시지 정보는 변경 없이 그대로 제공됩니다.

<sub>✏️ Tip: 필요 시 응답 표시 형식을 검토해 UI에 반영하세요.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->