### PR TITLE
Feature 채팅 내역 get api 구현

### DIFF
--- a/src/main/java/org/baljaguk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/baljaguk/domain/chat/controller/ChatRoomController.java
@@ -41,12 +41,13 @@ public class ChatRoomController {
             description = "roomId에 해당하는 채팅 내역을 커서(messageId, messageAt) 기반으로 조회합니다."
     )
     public ResponseEntity<ApiResponse<ChatMessageResponse>> getChatHistory(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long roomId,
             @RequestParam(required = false) Long cursorMessageId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorMessageAt,
             @RequestParam(defaultValue = "30") Integer size
     ){
-        ChatMessageResponse chatMessageResponse = chatMessageService.getChatHistory(roomId, cursorMessageId, cursorMessageAt, size);
+        ChatMessageResponse chatMessageResponse = chatMessageService.getChatHistory(customUserDetails,roomId, cursorMessageId, cursorMessageAt, size);
 
         return ResponseEntity.ok(ApiResponse.ok(chatMessageResponse));
     }

--- a/src/main/java/org/baljaguk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/baljaguk/domain/chat/controller/ChatRoomController.java
@@ -3,15 +3,18 @@ package org.baljaguk.domain.chat.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.baljaguk.domain.chat.entity.dto.ChatMessageResponse;
 import org.baljaguk.domain.chat.entity.dto.ChatRoomListResponse;
+import org.baljaguk.domain.chat.service.ChatMessageService;
 import org.baljaguk.domain.chat.service.ChatRoomService;
 import org.baljaguk.domain.user.dto.CustomUserDetails;
 import org.baljaguk.global.api.ApiResponse;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("api/v1/chat")
@@ -19,6 +22,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+
+    private final ChatMessageService chatMessageService;
 
     @GetMapping("/rooms")
     @Operation(summary = "채팅방 목록 조회",
@@ -28,5 +33,21 @@ public class ChatRoomController {
     ) {
         ChatRoomListResponse response = chatRoomService.getChatRooms(userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/{roomId}")
+    @Operation(
+            summary = "채팅 내역 조회",
+            description = "roomId에 해당하는 채팅 내역을 커서(messageId, messageAt) 기반으로 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<ChatMessageResponse>> getChatHistory(
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long cursorMessageId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorMessageAt,
+            @RequestParam(defaultValue = "30") Integer size
+    ){
+        ChatMessageResponse chatMessageResponse = chatMessageService.getChatHistory(roomId, cursorMessageId, cursorMessageAt, size);
+
+        return ResponseEntity.ok(ApiResponse.ok(chatMessageResponse));
     }
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageDto.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.baljaguk.domain.chat.entity.ChatMessage;
+
 import java.time.LocalDateTime;
 
 @Getter
@@ -20,4 +22,13 @@ public class ChatMessageDto {
     private Long userId;
 
     private LocalDateTime createdAt;
+
+    public static ChatMessageDto from(ChatMessage chatMessage) {
+        return ChatMessageDto.builder()
+                .message(chatMessage.getMessage())
+                .roomId(chatMessage.getChatRoom().getId())
+                .createdAt(chatMessage.getCreatedAt())
+                .userId(chatMessage.getUserId())
+                .build();
+    }
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -16,5 +17,9 @@ public class ChatMessageResponse {
     private List<ChatMessageDto> messages;
 
     private List<TeamMemberInfoDto> teamMembers;
+
+    private Long lastMessageId;
+
+    private LocalDateTime lastMessageAt;
 
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageResponse.java
@@ -1,0 +1,20 @@
+package org.baljaguk.domain.chat.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatMessageResponse {
+
+    private Long roomId;
+
+    private List<ChatMessageDto> messages;
+
+    private List<TeamMemberInfoDto> teamMembers;
+
+}

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageResponse.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/ChatMessageResponse.java
@@ -3,7 +3,6 @@ package org.baljaguk.domain.chat.entity.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -21,5 +20,7 @@ public class ChatMessageResponse {
     private Long lastMessageId;
 
     private LocalDateTime lastMessageAt;
+
+    private boolean hasNext;
 
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/TeamMemberInfoDto.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/TeamMemberInfoDto.java
@@ -3,6 +3,7 @@ package org.baljaguk.domain.chat.entity.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.baljaguk.domain.team.entity.TeamMember;
 
 @Getter
 @Builder
@@ -11,4 +12,13 @@ public class TeamMemberInfoDto {
     private Long userId;
     private String userName;
     private String userProfileUrl;
+
+    public static TeamMemberInfoDto from(TeamMember teamMember) {
+
+        return TeamMemberInfoDto.builder()
+                .userId(teamMember.getMember().getId())
+                .userName(teamMember.getMember().getName())
+                .userProfileUrl(teamMember.getMember().getProfileImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/org/baljaguk/domain/chat/entity/dto/TeamMemberInfoDto.java
+++ b/src/main/java/org/baljaguk/domain/chat/entity/dto/TeamMemberInfoDto.java
@@ -1,0 +1,14 @@
+package org.baljaguk.domain.chat.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TeamMemberInfoDto {
+    private Long userId;
+    private String userName;
+    private String userProfileUrl;
+}

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryCustom.java
@@ -9,4 +9,5 @@ import java.util.Map;
 public interface ChatMessageRepositoryCustom {
     Map<Long, Long> getUnreadCounts(Map<Long, LocalDateTime> lastReadTimes);
     List<ChatMessage> findLatestMessagesByRoomIds(List<Long> roomIds);
+    List<ChatMessage> findMessagesByCursor(Long roomId, Long lastMessageId, LocalDateTime lastMessageAt, Integer size);
 }

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -95,6 +95,6 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
         if(lastMessageId == null || lastMessageAt == null) return null;
 
         return chatMessage.createdAt.lt(lastMessageAt)
-                .or(chatMessage.createdAt.eq(lastMessageAt).and(chatMessage.chatRoom.id.lt(lastMessageId)));
+                .or(chatMessage.createdAt.eq(lastMessageAt).and(chatMessage.id.lt(lastMessageId)));
     }
 }

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -80,7 +80,10 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 
     @Override
     public List<ChatMessage> findMessagesByCursor(Long roomId, Long lastMessageId, LocalDateTime lastMessageAt, Integer size) {
-
+        //size 검증 절차
+        if (size <= 0) {
+            throw new IllegalArgumentException("size must be positive");
+        }
         return queryFactory.selectFrom(chatMessage)
                 .where(
                         chatMessage.chatRoom.id.eq(roomId),
@@ -93,6 +96,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 
     private BooleanExpression cursorCondition(Long lastMessageId, LocalDateTime lastMessageAt) {
         if(lastMessageId == null || lastMessageAt == null) return null;
+
 
         return chatMessage.createdAt.lt(lastMessageAt)
                 .or(chatMessage.createdAt.eq(lastMessageAt).and(chatMessage.id.lt(lastMessageId)));

--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.baljaguk.domain.chat.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -20,13 +21,14 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    private final QChatMessage chatMessage = QChatMessage.chatMessage;
+
     @Override
     public Map<Long, Long> getUnreadCounts(Map<Long, LocalDateTime> lastReadTimes) {
         if (lastReadTimes == null || lastReadTimes.isEmpty()) {
             return Collections.emptyMap();
         }
 
-        QChatMessage chatMessage = QChatMessage.chatMessage;
         BooleanBuilder builder = new BooleanBuilder();
 
         // 각 채팅방마다 마지막으로 읽은 시간 이후의 메시지를 조회하는 조건을 동적으로 생성
@@ -62,7 +64,6 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
             return Collections.emptyList();
         }
 
-        QChatMessage chatMessage = QChatMessage.chatMessage;
         QChatMessage subChatMessage = new QChatMessage("subChatMessage");
 
         // 각 채팅방 ID별로 가장 최근 메시지 ID(max(id))를 찾는 서브쿼리 사용
@@ -75,5 +76,25 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
                                 .groupBy(subChatMessage.chatRoom.id)
                 ))
                 .fetch();
+    }
+
+    @Override
+    public List<ChatMessage> findMessagesByCursor(Long roomId, Long lastMessageId, LocalDateTime lastMessageAt, Integer size) {
+
+        return queryFactory.selectFrom(chatMessage)
+                .where(
+                        chatMessage.chatRoom.id.eq(roomId),
+                        cursorCondition(lastMessageId,lastMessageAt)
+                )
+                .orderBy(chatMessage.createdAt.desc(), chatMessage.id.desc())
+                .limit(size+1)
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(Long lastMessageId, LocalDateTime lastMessageAt) {
+        if(lastMessageId == null || lastMessageAt == null) return null;
+
+        return chatMessage.createdAt.lt(lastMessageAt)
+                .or(chatMessage.createdAt.eq(lastMessageAt).and(chatMessage.chatRoom.id.lt(lastMessageId)));
     }
 }

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,74 @@
+package org.baljaguk.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.baljaguk.domain.chat.entity.ChatMessage;
+import org.baljaguk.domain.chat.entity.ChatRoom;
+import org.baljaguk.domain.chat.entity.dto.ChatMessageDto;
+import org.baljaguk.domain.chat.entity.dto.ChatMessageResponse;
+import org.baljaguk.domain.chat.entity.dto.TeamMemberInfoDto;
+import org.baljaguk.domain.chat.repository.ChatMessageRepository;
+import org.baljaguk.domain.chat.repository.ChatRoomRepository;
+import org.baljaguk.domain.team.repository.TeamMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    private final TeamMemberRepository teamMemberRepository;
+
+    private final ChatRoomRepository chatRoomRepository;
+
+
+    @Transactional(readOnly = true)
+    public ChatMessageResponse getChatHistory(Long roomId, Long cursorMessageId, LocalDateTime cursorMessageAt, Integer size) {
+
+       //chatRoom 조회
+       ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElse(null);
+
+       // chat history 조회 (size+1)로 조회함으로써 hasNext 판단
+       List<ChatMessage> chatMessages = chatMessageRepository.findMessagesByCursor(roomId, cursorMessageId, cursorMessageAt, size+1);
+
+       boolean hasNext = false;
+
+       // size보다 큰 messages가 들어오면 hasNext = true
+       if(chatMessages.size()>size) {
+           hasNext=true;
+           chatMessages.remove(chatMessages.size()-1);
+       }
+
+       // 다음 커서 정보 추출
+       ChatMessage lastMessage = chatMessages.get(chatMessages.size()-1);
+       Long nextCursorMessageId = lastMessage.getId();
+       LocalDateTime nextCursorMessageAt= lastMessage.getCreatedAt();
+
+       //ChatMessageResponse 클래스 chatMessages 필드
+       List<ChatMessageDto> chatMessageDtoList = chatMessages.stream()
+               .map(ChatMessageDto::from)
+               .toList();
+
+       //ChatMessageResponse 클래스 teamMembers 필드
+       List<TeamMemberInfoDto> teamMemberInfoDto = teamMemberRepository.findAllWithUserByTeamId(Objects.requireNonNull(chatRoom).getTeam().getId())
+               .stream()
+               .map(TeamMemberInfoDto::from)
+               .toList();
+
+        return ChatMessageResponse.builder()
+                .roomId(roomId)
+                .messages(chatMessageDtoList)
+                .hasNext(hasNext)
+                .lastMessageAt(nextCursorMessageAt)
+                .lastMessageId(nextCursorMessageId)
+                .teamMembers(teamMemberInfoDto)
+                .build();
+    }
+}

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
@@ -9,7 +9,6 @@ import org.baljaguk.domain.chat.entity.dto.ChatMessageResponse;
 import org.baljaguk.domain.chat.entity.dto.TeamMemberInfoDto;
 import org.baljaguk.domain.chat.repository.ChatMessageRepository;
 import org.baljaguk.domain.chat.repository.ChatRoomRepository;
-import org.baljaguk.domain.team.entity.TeamMember;
 import org.baljaguk.domain.team.repository.TeamMemberRepository;
 import org.baljaguk.domain.user.dto.CustomUserDetails;
 import org.baljaguk.global.api.ErrorCode;
@@ -35,7 +34,7 @@ public class ChatMessageService {
 
         // 1. roomId로 ChatRoom 조회, 없으면 예외 발생
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_TEAM));
+                .orElseThrow(() -> new IllegalArgumentException("채팅방 x: "+roomId));
 
         // 2. 사용자가 속한 Team 목록 조회
         List<Long> userTeams = teamMemberRepository.findTeamIdsByMemberId(customUserDetails.getUserId());

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
@@ -34,7 +34,7 @@ public class ChatMessageService {
 
         // 1. roomId로 ChatRoom 조회, 없으면 예외 발생
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방 x: "+roomId));
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_TEAM));
 
         // 2. 사용자가 속한 Team 목록 조회
         List<Long> userTeams = teamMemberRepository.findTeamIdsByMemberId(customUserDetails.getUserId());
@@ -50,23 +50,26 @@ public class ChatMessageService {
         // chat history 조회 (size+1)로 조회함으로써 hasNext 판단
         List<ChatMessage> chatMessages = chatMessageRepository.findMessagesByCursor(roomId, cursorMessageId, cursorMessageAt, size + 1);
 
-        boolean hasNext = false;
+        boolean hasNext;
 
         // size보다 큰 messages가 들어오면 hasNext = true
         if (chatMessages.size() > size) {
             hasNext = true;
             //마지막 삭제
             chatMessages.remove(chatMessages.size() - 1);
-        }
+        }else hasNext = false;
 
-        Long nextCursorMessageId = null;
-        LocalDateTime nextCursorMessageAt = null;
+        Long nextCursorMessageId;
+        LocalDateTime nextCursorMessageAt;
 
         // 다음 커서 정보 추출 (메시지가 있을 경우에만)
         if (!chatMessages.isEmpty()) {
             ChatMessage lastMessage = chatMessages.get(chatMessages.size() - 1);
             nextCursorMessageId = lastMessage.getId();
             nextCursorMessageAt = lastMessage.getCreatedAt();
+        }else {
+            nextCursorMessageId = null;
+            nextCursorMessageAt = null;
         }
 
 

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatMessageService.java
@@ -9,13 +9,16 @@ import org.baljaguk.domain.chat.entity.dto.ChatMessageResponse;
 import org.baljaguk.domain.chat.entity.dto.TeamMemberInfoDto;
 import org.baljaguk.domain.chat.repository.ChatMessageRepository;
 import org.baljaguk.domain.chat.repository.ChatRoomRepository;
+import org.baljaguk.domain.team.entity.TeamMember;
 import org.baljaguk.domain.team.repository.TeamMemberRepository;
+import org.baljaguk.domain.user.dto.CustomUserDetails;
+import org.baljaguk.global.api.ErrorCode;
+import org.baljaguk.global.api.GeneralException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -23,44 +26,61 @@ import java.util.Objects;
 public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
-
     private final TeamMemberRepository teamMemberRepository;
-
     private final ChatRoomRepository chatRoomRepository;
 
 
     @Transactional(readOnly = true)
-    public ChatMessageResponse getChatHistory(Long roomId, Long cursorMessageId, LocalDateTime cursorMessageAt, Integer size) {
+    public ChatMessageResponse getChatHistory(CustomUserDetails customUserDetails, Long roomId, Long cursorMessageId, LocalDateTime cursorMessageAt, Integer size) {
 
-       //chatRoom 조회
-       ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElse(null);
+        // 1. roomId로 ChatRoom 조회, 없으면 예외 발생
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_TEAM));
 
-       // chat history 조회 (size+1)로 조회함으로써 hasNext 판단
-       List<ChatMessage> chatMessages = chatMessageRepository.findMessagesByCursor(roomId, cursorMessageId, cursorMessageAt, size+1);
+        // 2. 사용자가 속한 Team 목록 조회
+        List<Long> userTeams = teamMemberRepository.findTeamIdsByMemberId(customUserDetails.getUserId());
 
-       boolean hasNext = false;
+        // 3. 사용자가 해당 팀(채팅방)에 속해 있는지 확인
+        boolean isMember = userTeams.stream()
+                .anyMatch(teamMember -> teamMember.equals(chatRoom.getTeam().getId()));
 
-       // size보다 큰 messages가 들어오면 hasNext = true
-       if(chatMessages.size()>size) {
-           hasNext=true;
-           chatMessages.remove(chatMessages.size()-1);
-       }
+        if (!isMember) {
+            throw new GeneralException(ErrorCode.NOT_MY_TEAM);
+        }
 
-       // 다음 커서 정보 추출
-       ChatMessage lastMessage = chatMessages.get(chatMessages.size()-1);
-       Long nextCursorMessageId = lastMessage.getId();
-       LocalDateTime nextCursorMessageAt= lastMessage.getCreatedAt();
+        // chat history 조회 (size+1)로 조회함으로써 hasNext 판단
+        List<ChatMessage> chatMessages = chatMessageRepository.findMessagesByCursor(roomId, cursorMessageId, cursorMessageAt, size + 1);
 
-       //ChatMessageResponse 클래스 chatMessages 필드
-       List<ChatMessageDto> chatMessageDtoList = chatMessages.stream()
-               .map(ChatMessageDto::from)
-               .toList();
+        boolean hasNext = false;
 
-       //ChatMessageResponse 클래스 teamMembers 필드
-       List<TeamMemberInfoDto> teamMemberInfoDto = teamMemberRepository.findAllWithUserByTeamId(Objects.requireNonNull(chatRoom).getTeam().getId())
-               .stream()
-               .map(TeamMemberInfoDto::from)
-               .toList();
+        // size보다 큰 messages가 들어오면 hasNext = true
+        if (chatMessages.size() > size) {
+            hasNext = true;
+            //마지막 삭제
+            chatMessages.remove(chatMessages.size() - 1);
+        }
+
+        Long nextCursorMessageId = null;
+        LocalDateTime nextCursorMessageAt = null;
+
+        // 다음 커서 정보 추출 (메시지가 있을 경우에만)
+        if (!chatMessages.isEmpty()) {
+            ChatMessage lastMessage = chatMessages.get(chatMessages.size() - 1);
+            nextCursorMessageId = lastMessage.getId();
+            nextCursorMessageAt = lastMessage.getCreatedAt();
+        }
+
+
+        //ChatMessageResponse 클래스 chatMessages 필드
+        List<ChatMessageDto> chatMessageDtoList = chatMessages.stream()
+                .map(ChatMessageDto::from)
+                .toList();
+
+        //ChatMessageResponse 클래스 teamMembers 필드
+        List<TeamMemberInfoDto> teamMemberInfoDto = teamMemberRepository.findAllWithUserByTeamId(chatRoom.getTeam().getId())
+                .stream()
+                .map(TeamMemberInfoDto::from)
+                .toList();
 
         return ChatMessageResponse.builder()
                 .roomId(roomId)

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatPersistenceService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatPersistenceService.java
@@ -9,7 +9,6 @@ import org.baljaguk.domain.chat.repository.ChatRoomRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #55 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

채팅 내역 조회 API 구현

- 커서(chatMessageId, createdAt) 기반 desc 정렬 후 가져오기

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<img width="908" height="310" alt="image" src="https://github.com/user-attachments/assets/e599688f-5854-49de-ac7d-c99db8e93bb0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 방 메시지 히스토리 조회 API(GET /{roomId})가 추가되었습니다. (쿼리: cursorMessageId, cursorMessageAt(ISO 날짜-시간), size(기본 30))
  * 커서 기반 페이지네이션으로 이전/다음 메시지 효율적 조회 및 hasNext 제공.
  * 메시지 목록과 작성시간·작성자 ID 등 메타정보, 채팅 참여자(이름·프로필) 정보가 함께 반환됩니다.
  * 방 접근은 해당 방의 팀/참여자만 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->