### PR TITLE
fix: 지원자 목록에서 승인 및 거절된 상태의 지원자만 조회하여 상태값도 함께 응답

### DIFF
--- a/src/main/java/org/baljaguk/domain/team/dto/response/TeamApplicantListResponse.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/response/TeamApplicantListResponse.java
@@ -1,5 +1,7 @@
 package org.baljaguk.domain.team.dto.response;
 
+import org.baljaguk.domain.team.entity.RegisterStatus;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,9 +18,10 @@ public record TeamApplicantListResponse(
             Long userId,
             String profileImageUrl,
             String name,
-            List<String> aiTags
+            List<String> aiTags,
+            RegisterStatus status
     ) {
-        public static ApplicantInfo of(Long userId, String profileImageUrl, String name, String aiTagsCsv) {
+        public static ApplicantInfo of(Long userId, String profileImageUrl, String name, String aiTagsCsv, RegisterStatus registerStatus) {
 
             // aiTagsCsv가 null이거나 빈 문자열이면 빈 리스트 반환
             List<String> tags = (aiTagsCsv == null || aiTagsCsv.isBlank())
@@ -28,7 +31,7 @@ public record TeamApplicantListResponse(
                     .filter(s -> !s.isEmpty())  // 공백 요소 제거
                     .toList();
 
-            return new ApplicantInfo(userId, profileImageUrl, name, tags);
+            return new ApplicantInfo(userId, profileImageUrl, name, tags, registerStatus);
         }
     }
 }

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamApplyRepositoryImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamApplyRepositoryImpl.java
@@ -37,7 +37,7 @@ public class TeamApplyRepositoryImpl implements TeamApplyRepositoryCustom {
                 .join(teamApply.user).fetchJoin()
                 .where(
                         teamApply.team.id.eq(teamId),
-                        teamApply.status.eq(RegisterStatus.REQUESTED)
+                        teamApply.status.in(RegisterStatus.ACCEPTED, RegisterStatus.REQUESTED)
                 )
                 .fetch();
     }

--- a/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
@@ -455,7 +455,8 @@ public class TeamServiceImpl implements TeamService {
                                 apply.getUser().getId(),
                                 apply.getUser().getProfileImageUrl(),
                                 apply.getUser().getName(),
-                                apply.getAiTags()
+                                apply.getAiTags(),
+                                apply.getStatus()
                         )
                 )
                 .toList();


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #68 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 나의 모집 목록에서 현재 승인된 지원자에 대한 팀 멤버수는 동일하게 응답하고 있어 수정하지 않음
- 지원자 목록에서는 승인 또는 신청 중인 지원에 대해서만 조회하도록 수정했고, 신청의 상태도 응답 스펙에 추가함

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
