### PR TITLE
[FEATURE] 나의 모집완료된 팀을 만료 상태로 변경하는 API

### DIFF
--- a/src/main/java/org/baljaguk/domain/team/controller/TeamController.java
+++ b/src/main/java/org/baljaguk/domain/team/controller/TeamController.java
@@ -262,4 +262,20 @@ public class TeamController {
         teamService.closeTeamRecruit(teamId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
+
+    @PatchMapping("/{teamId}/expire")
+    @Operation(
+            summary = "팀 모집 만료(EXPIRED) 처리 API",
+            description = """
+            팀장이 자신의 팀 모집 상태를 'EXPIRED'로 변경합니다.\n
+            팀장이 아닌 사용자가 호출하면 권한 오류가 발생합니다.
+            """
+    )
+    public ResponseEntity<ApiResponse<Void>> expireTeamRecruit(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        teamService.expireTeamRecruit(teamId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
 }

--- a/src/main/java/org/baljaguk/domain/team/repository/TeamRepository.java
+++ b/src/main/java/org/baljaguk/domain/team/repository/TeamRepository.java
@@ -25,8 +25,12 @@ public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositor
     from Team t
     join fetch t.contest c
     where t.teamLeader.id = :userId
+      and t.status in (:statuses)
 """)
-    List<Team> findAllWithContestByTeamLeaderId(@Param("userId") Long userId);
+    List<Team> findAllWithContestByTeamLeaderId(
+            @Param("userId") Long userId,
+            @Param("statuses") List<TeamStatus> statuses
+    );
 
     @Query("""
     select t

--- a/src/main/java/org/baljaguk/domain/team/service/TeamService.java
+++ b/src/main/java/org/baljaguk/domain/team/service/TeamService.java
@@ -39,4 +39,6 @@ public interface TeamService {
     void cancelMyApply(Long userId, Long teamId);
 
     void closeTeamRecruit(Long teamId, Long userId);
+
+    void expireTeamRecruit(Long teamId, Long userId);
 }

--- a/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
@@ -324,8 +324,11 @@ public class TeamServiceImpl implements TeamService {
     @Transactional(readOnly = true)
     public MyRecruitListResponse getMyRecruitList(Long userId) {
 
-        // 1) 팀장 기준으로 팀 + 공모전 Fetch Join 조회
-        List<Team> myTeams = teamRepository.findAllWithContestByTeamLeaderId(userId);
+        // 1) 조회할 TeamStatus 목록 정의
+        List<TeamStatus> statuses = List.of(TeamStatus.OPEN, TeamStatus.CLOSED);
+
+        // 2) Fetch Join 조회
+        List<Team> myTeams = teamRepository.findAllWithContestByTeamLeaderId(userId, statuses);
 
         List<MyRecruitListResponse.MyRecruitInfoResponse> result = myTeams.stream()
                 .map(team -> {
@@ -659,5 +662,27 @@ public class TeamServiceImpl implements TeamService {
 
         // 5) 모집 마감 처리
         team.updateStatus(TeamStatus.CLOSED);
+    }
+
+    @Override
+    @Transactional
+    public void expireTeamRecruit(Long teamId, Long userId) {
+
+        // 1) 팀 조회
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_TEAM));
+
+        // 2) 요청자가 팀장인지 확인
+        if (!team.getTeamLeader().getId().equals(userId)) {
+            throw new GeneralException(ErrorCode.NOT_TEAM_LEADER);
+        }
+
+        // 3) 현재 상태가 CLOSED가 아니라면 예외
+        if (team.getStatus() != TeamStatus.CLOSED) {
+            throw new GeneralException(ErrorCode.TEAM_NOT_CLOSED);
+        }
+
+        // 4) 상태 변경: CLOSED → EXPIRED
+        team.updateStatus(TeamStatus.EXPIRED);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #70 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 나의 모집 팀 만료시키는 API를 구현했습니다.
- 내가 팀 리더일 경우만 가능합니다.
- 나의 모집 팀 목록 조회시 EXPIRED는 조회되지 않도록 수정했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 팀 모집을 '만료됨' 상태로 표시할 수 있는 기능이 추가되었습니다. 팀 리더가 모집을 완료한 후 팀을 만료된 상태로 변경할 수 있습니다.

## 개선사항
* 팀 모집 목록 조회 시 상태 기반 필터링이 개선되어 더욱 정확한 정보 표시가 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->