### PR TITLE
[FIX] 팀 목록 조회에서 CanApply 세분화

### DIFF
--- a/src/main/java/org/baljaguk/domain/team/controller/TeamController.java
+++ b/src/main/java/org/baljaguk/domain/team/controller/TeamController.java
@@ -51,7 +51,13 @@ public class TeamController {
 
     @Operation(
             summary = "공모전별 팀 목록 조회",
-            description = "특정 공모전에 등록된 OPEN 상태의 팀 목록을 조회합니다."
+            description = "특정 공모전에 등록된 OPEN 상태의 팀 목록을 조회합니다.\n" +
+                    " - OK: 신청 가능\n" +
+                    " - TEAM_LEADER: 본인이 팀장\n" +
+                    " - ALREADY_APPLIED: 이미 해당 팀에 신청함\n" +
+                    " - APPLIED_IN_OTHER_TEAM: 동일 공모전 다른 팀에 신청됨\n" +
+                    " - ALREADY_MEMBER: 이미 팀원임\n" +
+                    " - NOT_LOGIN: 로그인하지 않음"
     )
     @GetMapping("/{contestId}")
     public ResponseEntity<ApiResponse<ContestTeamListResponse>> getTeamList(

--- a/src/main/java/org/baljaguk/domain/team/dto/response/ContestTeamListResponse.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/response/ContestTeamListResponse.java
@@ -35,7 +35,7 @@ public record ContestTeamListResponse(
             @Schema(description = "팀 상태 (OPEN만 조회됨)", example = "OPEN")
             String status,
 
-            @Schema(description = "신청 가능 여부", example = "true")
+            @Schema(description = "신청 가능 여부", implementation = CanApply.class)
             CanApply canApply
     ) {
         public static TeamInfo of(Long teamId,

--- a/src/main/java/org/baljaguk/domain/team/dto/response/ContestTeamListResponse.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/response/ContestTeamListResponse.java
@@ -1,6 +1,7 @@
 package org.baljaguk.domain.team.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.baljaguk.domain.team.dto.response.enums.CanApply;
 
 import java.util.List;
 
@@ -35,14 +36,14 @@ public record ContestTeamListResponse(
             String status,
 
             @Schema(description = "신청 가능 여부", example = "true")
-            Boolean canApply
+            CanApply canApply
     ) {
         public static TeamInfo of(Long teamId,
                                   String title,
                                   Integer maxMember,
                                   Long currentMemberCount,
                                   String status,
-                                  Boolean canApply) {
+                                  CanApply canApply) {
 
             return new TeamInfo(teamId, title, maxMember, currentMemberCount, status, canApply);
         }

--- a/src/main/java/org/baljaguk/domain/team/dto/response/enums/CanApply.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/response/enums/CanApply.java
@@ -1,9 +1,26 @@
 package org.baljaguk.domain.team.dto.response.enums;
 
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "팀 신청 가능 여부 상태값")
 public enum CanApply {
+
+    @Schema(description = "신청 가능")
     OK,
+
+    @Schema(description = "본인이 팀장이라 신청 불가")
     TEAM_LEADER,
+
+    @Schema(description = "이미 이 팀에 신청한 상태")
     ALREADY_APPLIED,
+
+    @Schema(description = "동일 공모전의 다른 팀에 이미 신청함")
     APPLIED_IN_OTHER_TEAM,
-    ALREADY_MEMBER;
+
+    @Schema(description = "동일 공모전의 팀에 이미 가입된 상태")
+    ALREADY_MEMBER,
+
+    @Schema(description = "로그인이 필요한 상태")
+    NOT_LOGIN;
 }

--- a/src/main/java/org/baljaguk/domain/team/dto/response/enums/CanApply.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/response/enums/CanApply.java
@@ -1,0 +1,9 @@
+package org.baljaguk.domain.team.dto.response.enums;
+
+public enum CanApply {
+    OK,
+    TEAM_LEADER,
+    ALREADY_APPLIED,
+    APPLIED_IN_OTHER_TEAM,
+    ALREADY_MEMBER;
+}

--- a/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
@@ -9,6 +9,7 @@ import org.baljaguk.domain.contest.repository.ContestRepository;
 import org.baljaguk.domain.team.dto.request.CreateTeamRequest;
 import org.baljaguk.domain.team.dto.request.TeamApplyRequest;
 import org.baljaguk.domain.team.dto.response.*;
+import org.baljaguk.domain.team.dto.response.enums.CanApply;
 import org.baljaguk.domain.team.entity.*;
 import org.baljaguk.domain.team.repository.*;
 import org.baljaguk.domain.user.entity.User;
@@ -144,7 +145,7 @@ public class TeamServiceImpl implements TeamService {
                 .map(team -> {
                     Long memberCount = teamMemberRepository.countByTeam(team);
 
-                    boolean canApply = false;
+                    CanApply canApply = CanApply.OK;
 
                     if (currentUser != null) {
                         canApply = canUserApplyTeam(currentUser, team);
@@ -707,11 +708,11 @@ public class TeamServiceImpl implements TeamService {
         team.updateStatus(TeamStatus.EXPIRED);
     }
 
-    public boolean canUserApplyTeam(User user, Team team) {
+    public CanApply canUserApplyTeam(User user, Team team) {
 
         // 1) 본인이 팀장인 경우
         if (team.getTeamLeader().getId().equals(user.getId())) {
-            return false;
+            return CanApply.TEAM_LEADER;
         }
 
         // 2) 해당 팀에 이미 신청했는지
@@ -719,7 +720,7 @@ public class TeamServiceImpl implements TeamService {
                 user, team, RegisterStatus.REQUESTED
         );
         if (alreadyApplied) {
-            return false;
+            return CanApply.ALREADY_APPLIED;
         }
 
         // 3) 동일 공모전에 이미 신청했는지
@@ -727,7 +728,7 @@ public class TeamServiceImpl implements TeamService {
                 user, team.getContest(), RegisterStatus.REQUESTED
         );
         if (requestedInContest) {
-            return false;
+            return CanApply.APPLIED_IN_OTHER_TEAM;
         }
 
         // 4) 동일 공모전에 이미 팀원으로 소속되어 있는지
@@ -735,10 +736,10 @@ public class TeamServiceImpl implements TeamService {
                 user, team.getContest()
         );
         if (isAlreadyMember) {
-            return false;
+            return CanApply.ALREADY_MEMBER;
         }
 
-        // 모두 통과하면 신청 가능
-        return true;
+        // 모두 통과 → 신청 가능
+        return CanApply.OK;
     }
 }

--- a/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
@@ -149,6 +149,8 @@ public class TeamServiceImpl implements TeamService {
 
                     if (currentUser != null) {
                         canApply = canUserApplyTeam(currentUser, team);
+                    } else {
+                        canApply = CanApply.NOT_LOGIN;
                     }
 
                     return ContestTeamListResponse.TeamInfo.of(

--- a/src/main/java/org/baljaguk/domain/user/controller/UserController.java
+++ b/src/main/java/org/baljaguk/domain/user/controller/UserController.java
@@ -58,10 +58,11 @@ public class UserController {
                     로그인한 사용자의 학력 정보를 수정합니다.\n
                     • 대학교명\n
                     • 전공\n
-                    • education ("HIGH_SCHOOL, UNIVERSITY")\n
-                    • recognizedDegree ("ASSOCIATE, BACHELOR, MASTER")\n
+                    • education ("HIGH_SCHOOL, UNIVERSITY, MASTER")\n
+                    • recognizedDegree ("ASSOCIATE, BACHELOR")\n
                     
-                    위 네 가지 정보를 한 번에 업데이트합니다.
+                    위 네 가지 정보를 한 번에 업데이트합니다.\n
+                    MASTER의 경우, recognizedDegree를 null로 받습니다.
                     """
     )
     public ResponseEntity<ApiResponse<String>> updateEducation(


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #88 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- CanApply를 불린값으로 할 경우, 어떤 이유로 팀 지원을 못하는지 모릅니다.
- 그렇기 때문에, CanApply를 열거형으로 응답하는 것으로 수정했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팀 신청 가능 여부를 보다 구체적으로 표시하는 상태 체계 도입 (신청 가능, 팀 리더, 이미 신청, 다른 팀 신청, 이미 멤버, 미로그인 등)

* **문서 개선**
  * 팀 목록 조회 API 엔드포인트의 상세한 응답 상태 코드 설명 추가
  * 사용자 교육 정보 업데이트 API 문서 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->