### PR TITLE
[FIX] 나의 팀 상세조회시 응답 스펙 수정 및 팀 생성시 예외 처리

### DIFF
--- a/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/baljaguk/domain/chat/repository/ChatRoomRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT cr FROM ChatRoom cr JOIN FETCH cr.team WHERE cr.team.id IN :teamIds")
     List<ChatRoom> findByTeamIdIn(@Param("teamIds") List<Long> teamIds);
 
     boolean existsByTeamId(Long teamId);
+
+    Optional<ChatRoom> findByTeamId(Long teamId);
 }

--- a/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/baljaguk/domain/chat/service/ChatRoomService.java
@@ -123,7 +123,7 @@ public class ChatRoomService {
 
             // 2. 중복 방지
         if (chatRoomRepository.existsByTeamId(team.getId())) {
-            throw new RuntimeException("이미 해당 팀의 채팅방이 존재합니다.");
+            throw new GeneralException(ErrorCode.ALREADY_EXIST_CHATROOM);
         }
 
         // 3. 채팅방 생성

--- a/src/main/java/org/baljaguk/domain/team/dto/response/MyTeamDetailResponse.java
+++ b/src/main/java/org/baljaguk/domain/team/dto/response/MyTeamDetailResponse.java
@@ -10,7 +10,8 @@ public record MyTeamDetailResponse(
         String myMemberType,   // 나의 팀원 타입
         String memo,
         List<MemberInfo> members,
-        Long contestId
+        Long contestId,
+        Long chatRoomId
 ) {
 
     public static MyTeamDetailResponse of(String teamTitle,
@@ -20,7 +21,8 @@ public record MyTeamDetailResponse(
                                           String myMemberType,
                                           String memo,
                                           List<MemberInfo> members,
-                                          Long contestId) {
+                                          Long contestId,
+                                          Long chatRoomId) {
         return new MyTeamDetailResponse(
                 teamTitle,
                 contestName,
@@ -29,7 +31,8 @@ public record MyTeamDetailResponse(
                 myMemberType,
                 memo,
                 members,
-                contestId
+                contestId,
+                chatRoomId
         );
     }
 

--- a/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/org/baljaguk/domain/team/service/TeamServiceImpl.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.baljaguk.domain.chat.entity.ChatRoom;
+import org.baljaguk.domain.chat.repository.ChatRoomRepository;
 import org.baljaguk.domain.contest.entity.Contest;
 import org.baljaguk.domain.contest.repository.ContestRepository;
 import org.baljaguk.domain.team.dto.request.CreateTeamRequest;
@@ -37,6 +39,7 @@ public class TeamServiceImpl implements TeamService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamApplyRepository teamApplyRepository;
     private final AnswerRepository answerRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     private final GeminiClient geminiClient;
 
@@ -88,6 +91,33 @@ public class TeamServiceImpl implements TeamService {
 
         if (existsOpenTeam) {
             throw new GeneralException(ErrorCode.CONTEST_ALREADY_HAS_OPEN_TEAM);
+        }
+
+        // ---------------------------
+        // [추가 2] 해당 공모전에 신청(REQUESTED)한 팀이 있는 경우
+        // → 팀을 생성할 수 없음
+        // ---------------------------
+        boolean alreadyApplied = teamApplyRepository.existsByUserAndTeamContestAndStatus(
+                user,
+                contest,
+                RegisterStatus.REQUESTED
+        );
+
+        if (alreadyApplied) {
+            throw new GeneralException(ErrorCode.ALREADY_REQUESTED_IN_CONTEST);
+        }
+
+        // ---------------------------
+        // [추가 3] 이미 해당 공모전의 팀원으로 소속되어 있는 경우
+        // → 다른 팀 생성 불가
+        // ---------------------------
+        boolean alreadyMember = teamMemberRepository.existsByMemberAndTeamContest(
+                user,
+                contest
+        );
+
+        if (alreadyMember) {
+            throw new GeneralException(ErrorCode.ALREADY_JOINED_IN_CONTEST);
         }
 
         // 3. 팀 엔티티 생성
@@ -442,6 +472,10 @@ public class TeamServiceImpl implements TeamService {
                 ))
                 .toList();
 
+        // 팀id에 해당하는 채팅방 조회
+        ChatRoom chatRoom = chatRoomRepository.findByTeamId(team.getId())
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_CHATROOM));
+
         // 최종 응답 DTO 생성
         return MyTeamDetailResponse.of(
                 team.getTitle(),
@@ -451,7 +485,8 @@ public class TeamServiceImpl implements TeamService {
                 myType,
                 team.getMemo(),
                 members,
-                team.getContest().getId()
+                team.getContest().getId(),
+                chatRoom.getId()
         );
     }
 

--- a/src/main/java/org/baljaguk/global/api/ErrorCode.java
+++ b/src/main/java/org/baljaguk/global/api/ErrorCode.java
@@ -89,6 +89,7 @@ public enum ErrorCode {
      * 409 Conflict
      */
     ALREADY_APPLIED_TEAM(HttpStatus.CONFLICT, 40900, "이미 신청한 팀입니다."),
+    ALREADY_EXIST_CHATROOM(HttpStatus.CONFLICT, 40901, "이미 해당 팀에 대한 채팅방이 존재합니다."),
 
 
     /**

--- a/src/main/java/org/baljaguk/global/api/ErrorCode.java
+++ b/src/main/java/org/baljaguk/global/api/ErrorCode.java
@@ -76,6 +76,9 @@ public enum ErrorCode {
     APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, 40408, "신청을 찾을 수 없습니다."),
     TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 40409, "해당 팀원을 찾을 수 없습니다."),
 
+    // 채팅방 관련
+    NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, 40410, "채팅방을 찾을 수 없습니다."),
+
     /**
      * 405 METHOD_NOT_ALLOWED
      */


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #99 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 야호 100번째 피알
- 나의 팀 상세조회 API 응답값으로 팀에 해당하는 채팅방의 id도 추가합니다.
- 팀 신청과 마찬가지로 팀 생성시에도 동일 공모전의 팀에 소속 or 신청 중이라면 팀 생성을 할 수 없도록 검증 및 예외를 추가했습니다.
- 채팅방 생성에 대해 중복 생성에 대한 호출을 서버단에서도 검증하도록 추가했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팀과 채팅방 기능 통합 - 팀 상세 정보 조회 시 연결된 채팅방 정보가 제공됩니다.

* **버그 수정**
  * 중복된 채팅방 생성 시 더욱 명확한 오류 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->